### PR TITLE
Add current simulation time to control bar. TG-34

### DIFF
--- a/src/main/java/com/github/bachelorpraktikum/dbvisualization/view/MainController.java
+++ b/src/main/java/com/github/bachelorpraktikum/dbvisualization/view/MainController.java
@@ -55,7 +55,9 @@ import javafx.scene.control.cell.TextFieldListCell;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.HBox;
 import javafx.scene.layout.Pane;
+import javafx.scene.layout.Priority;
 import javafx.scene.layout.StackPane;
 import javafx.scene.shape.Shape;
 import javafx.stage.Stage;
@@ -91,6 +93,10 @@ public class MainController {
     private ToggleButton logToggle;
     @FXML
     private ListView<Event> logList;
+    @FXML
+    private TextField timeText;
+    @FXML
+    private HBox rightSpacer;
 
     @FXML
     private Pane centerPane;
@@ -102,6 +108,7 @@ public class MainController {
 
     @FXML
     private void initialize() {
+        HBox.setHgrow(rightSpacer, Priority.ALWAYS);
         this.listeners = new WeakHashMap<>();
         fireOnEnterPress(closeButton);
         fireOnEnterPress(logToggle);
@@ -158,9 +165,10 @@ public class MainController {
             }
         };
         logList.setCellFactory(listCellFactory);
-        logList.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) ->
-                Element.in(ContextHolder.getInstance().getContext()).setTime(newValue.getTime())
-        );
+        logList.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> {
+            Element.in(ContextHolder.getInstance().getContext()).setTime(newValue.getTime());
+            timeText.setText(String.format("%dms", newValue.getTime()));
+        });
 
         ChangeListener<Number> boundsListener = (observable, oldValue, newValue) -> {
             if (ContextHolder.getInstance().hasContext()) {

--- a/src/main/java/com/github/bachelorpraktikum/dbvisualization/view/MainView.fxml
+++ b/src/main/java/com/github/bachelorpraktikum/dbvisualization/view/MainView.fxml
@@ -7,34 +7,36 @@
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.control.ToggleButton?>
+<?import javafx.scene.control.ToolBar?>
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.FlowPane?>
-<?import javafx.scene.layout.StackPane?>
-
+<?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.Pane?>
-<BorderPane fx:id="rootPane" prefHeight="600" prefWidth="800" xmlns="http://javafx.com/javafx/8.0.60" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.github.bachelorpraktikum.dbvisualization.view.MainController">
+<?import javafx.scene.layout.StackPane?>
+<BorderPane fx:id="rootPane" prefHeight="600" prefWidth="800"
+            xmlns="http://javafx.com/javafx/8.0.60" xmlns:fx="http://javafx.com/fxml/1"
+            fx:controller="com.github.bachelorpraktikum.dbvisualization.view.MainController">
     <top>
-        <AnchorPane>
+        <StackPane>
             <children>
-                <FlowPane alignment="CENTER_LEFT" hgap="5.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.topAnchor="0.0">
-                    <ToggleButton fx:id="logToggle" text="%show_hide_logs" />
-                </FlowPane>
-                <FlowPane alignment="CENTER_RIGHT" hgap="5.0" AnchorPane.bottomAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-                    <children>
-                        <ToggleButton fx:id="legendButton" text="%legend" />
-                        <Button fx:id="closeButton" text="%close_data_source" />
-                    </children>
-                </FlowPane>
+                <ToolBar>
+                    <items>
+                        <ToggleButton fx:id="logToggle" text="%show_hide_logs"/>
+                        <Label text="%current_simulation_time"/>
+                        <TextField fx:id="timeText" editable="false" prefHeight="25.0"
+                                   prefWidth="100.0" text="0ms"/>
+                        <HBox fx:id="rightSpacer" alignment="CENTER_RIGHT"/>
+                        <ToggleButton fx:id="legendButton" text="%legend"/>
+                        <Button fx:id="closeButton" text="%close_data_source"/>
+                    </items>
+                </ToolBar>
             </children>
-            <padding>
-                <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
-            </padding>
-        </AnchorPane>
+        </StackPane>
     </top>
     <left>
         <StackPane fx:id="leftPane">
-            <ListView fx:id="logList" />
+            <ListView fx:id="logList"/>
         </StackPane>
     </left>
     <center>
@@ -44,8 +46,9 @@
     </center>
     <right>
         <StackPane fx:id="sidebar" maxWidth="240">
-            <ListView fx:id="legend" fixedCellSize="0.0" style="-fx-background-color: #ccc;" visible="false">
-                <Label text="Legend goes here." />
+            <ListView fx:id="legend" fixedCellSize="0.0" style="-fx-background-color: #ccc;"
+                      visible="false">
+                <Label text="Legend goes here."/>
             </ListView>
             <BorderPane>
                 <center>
@@ -54,13 +57,18 @@
                 </center>
                 <top>
                     <AnchorPane>
-                        <TextField fx:id="filterText" promptText="%filter" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" />
-                        <FlowPane fx:id="filterPane" hgap="4" vgap="4" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="30.0">
-                            <CheckBox fx:id="elementFilter" selected="true" text="%filter_elements" />
-                            <CheckBox fx:id="trainFilter" selected="true" text="%filter_trains" />
+                        <TextField fx:id="filterText" promptText="%filter"
+                                   AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0"
+                                   AnchorPane.topAnchor="0.0"/>
+                        <FlowPane fx:id="filterPane" hgap="4" vgap="4" AnchorPane.bottomAnchor="0.0"
+                                  AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0"
+                                  AnchorPane.topAnchor="30.0">
+                            <CheckBox fx:id="elementFilter" selected="true"
+                                      text="%filter_elements"/>
+                            <CheckBox fx:id="trainFilter" selected="true" text="%filter_trains"/>
                         </FlowPane>
                         <padding>
-                            <Insets bottom="5.0" />
+                            <Insets bottom="5.0"/>
                         </padding>
                     </AnchorPane>
                 </top>

--- a/src/main/resources/bundles/localization.properties
+++ b/src/main/resources/bundles/localization.properties
@@ -12,3 +12,4 @@ legend=Legend
 filter=Filter...
 filter_elements=Show elements
 filter_trains=Show trains
+current_simulation_time=current simulation time:

--- a/src/main/resources/bundles/localization_de_DE.properties
+++ b/src/main/resources/bundles/localization_de_DE.properties
@@ -11,3 +11,4 @@ legend=Legende
 filter=Filtern...
 filter_elements=Elemente anzeigen
 filter_trains=Züge anzeigen
+current_simulation_time=Aktuelle Simulationszeit:


### PR DESCRIPTION
This also replaces the old control bar with an actual toolbar.

The rationale for using a (currently non-editable) TextField instead of a Label for showing the current time is to allow users to manually enter a time in a future version.