### PR TITLE
Stop simulation on data source close

### DIFF
--- a/src/main/java/com/github/bachelorpraktikum/dbvisualization/view/MainController.java
+++ b/src/main/java/com/github/bachelorpraktikum/dbvisualization/view/MainController.java
@@ -619,6 +619,7 @@ public class MainController {
 
     private void showSourceChooser() {
         if (graph != null) {
+            simulation.stop();
             centerPane.getChildren().remove(graph.getGroup());
             graph = null;
         }


### PR DESCRIPTION
Bug description:
When the user closed the data source while the simulation was auto-playing, the program continuously threw IllegalStateExceptions from ContextHolder.getContext().