### PR TITLE
Feature/train init with time TG-42

### DIFF
--- a/src/main/java/com/github/bachelorpraktikum/dbvisualization/logparser/GraphParser.java
+++ b/src/main/java/com/github/bachelorpraktikum/dbvisualization/logparser/GraphParser.java
@@ -122,7 +122,8 @@ public final class GraphParser {
         public Context visitMv_init(LogParser.Mv_initContext ctx) {
             Train train = Train.in(context).get(ctx.train_name().getText());
             Edge edge = Edge.in(context).get(ctx.edge_name().getText());
-            train.eventFactory().init(edge);
+            int time = timeVisitor.visitTime(ctx.time());
+            train.eventFactory().init(time, edge);
             return context;
         }
 

--- a/src/main/java/com/github/bachelorpraktikum/dbvisualization/model/train/TrainEvent.java
+++ b/src/main/java/com/github/bachelorpraktikum/dbvisualization/model/train/TrainEvent.java
@@ -19,12 +19,12 @@ abstract class TrainEvent implements Event {
     private final int time;
     private final int distance;
     private final int totalDistance;
-    @Nonnull
+    @Nullable
     private final TrainPosition position;
     @Nonnull
     private final List<String> warnings;
 
-    private TrainEvent(int index, Train train, int time, int distance, int totalDistance, TrainPosition position) {
+    private TrainEvent(int index, Train train, int time, int distance, int totalDistance, @Nullable TrainPosition position) {
         this.index = index;
         this.train = train;
         this.time = time;
@@ -66,7 +66,7 @@ abstract class TrainEvent implements Event {
         return totalDistance;
     }
 
-    @Nonnull
+    @Nullable
     final TrainPosition getPosition() {
         return position;
     }
@@ -122,7 +122,7 @@ abstract class TrainEvent implements Event {
     static class Speed extends TrainEvent {
         private final int speed;
 
-        private Speed(int index, Train train, int time, int distance, int totalDistance, TrainPosition position, int speed) {
+        private Speed(int index, Train train, int time, int distance, int totalDistance, @Nullable TrainPosition position, int speed) {
             super(index, train, time, distance, totalDistance, position);
             this.speed = speed;
         }
@@ -161,16 +161,38 @@ abstract class TrainEvent implements Event {
     }
 
     @ParametersAreNonnullByDefault
+    static class Start extends Speed {
+        Start(Train train) {
+            super(0, train, 0, 0, 0, null, 0);
+        }
+
+        @Nonnull
+        @Override
+        Builder stateBuilder() {
+            return super.stateBuilder().initialized(false);
+        }
+
+        @Nonnull
+        @Override
+        public String getDescription() {
+            return getTrain().getReadableName() + ": Start{"
+                    + "time=" +getTime()
+                    + ", this event purely serves as a helper for interpolation";
+        }
+    }
+
+    @ParametersAreNonnullByDefault
     static class Init extends Speed {
-        Init(Train train, Edge startEdge) {
-            super(0, train, 0, 0, 0, TrainPosition.init(train, startEdge), 0);
+        Init(int time, Train train, Edge startEdge) {
+            super(1, train, time, 0, 0, TrainPosition.init(train, startEdge), 0);
         }
 
         @Nonnull
         @Override
         public String getDescription() {
             return getTrain().getReadableName() + ": Init{"
-                    + "startEdge=" + getPosition().getBackEdge().getName()
+                    + "time=" + getTime()
+                    + ", startEdge=" + getPosition().getBackEdge().getName()
                     + "}";
         }
     }

--- a/src/main/java/com/github/bachelorpraktikum/dbvisualization/view/train/TrainView.java
+++ b/src/main/java/com/github/bachelorpraktikum/dbvisualization/view/train/TrainView.java
@@ -62,7 +62,11 @@ public final class TrainView {
 
     private void updateTrain(int time) {
         path.getElements().clear();
-        Train.Position trainPosition = train.getState(time).getPosition();
+        Train.State state = train.getState(time);
+        if(!state.isInitialized()) {
+            return;
+        }
+        Train.Position trainPosition = state.getPosition();
         List<Edge> edges = trainPosition.getEdges();
         List<PathElement> elements = new LinkedList<>();
 

--- a/src/test/java/com/github/bachelorpraktikum/dbvisualization/model/TrainTest.java
+++ b/src/test/java/com/github/bachelorpraktikum/dbvisualization/model/TrainTest.java
@@ -93,7 +93,7 @@ public class TrainTest {
     public void testGetStateNegativeTime() {
         Train train = Train.in(context).create("t", "train", 20);
         Edge edge = createEdges(30)[0];
-        train.eventFactory().init(edge);
+        train.eventFactory().init(0, edge);
 
         expected.expect(IllegalArgumentException.class);
         train.getState(-1);
@@ -102,15 +102,18 @@ public class TrainTest {
     @Test
     public void testGetStateNotInitialized() {
         Train train = Train.in(context).create("t", "train", 20);
+        assertFalse(train.getState(0).isInitialized());
+        assertFalse(train.getState(100).isInitialized());
+
         expected.expect(IllegalStateException.class);
-        train.getState(0);
+        train.getState(0).getPosition();
     }
 
     @Test
     public void testInitStart() {
         Train train = Train.in(context).create("t", "train", 20);
         Edge edge = createEdges(30)[0];
-        train.eventFactory().init(edge);
+        train.eventFactory().init(0, edge);
 
         Train.State state = train.getState(0);
         assertEquals(train.getLength(), state.getPosition().getFrontDistance());
@@ -118,26 +121,28 @@ public class TrainTest {
         assertEquals(edge, state.getPosition().getFrontEdge());
         assertEquals(edge, state.getPosition().getBackEdge());
         assertEquals(0, state.getTotalDistance());
+        assertTrue(state.isInitialized());
     }
 
     @Test
     public void testInitMiddle() {
         Train train = Train.in(context).create("t", "train", 20);
         Edge edge2 = createEdges(30, 40, 50)[1];
-        train.eventFactory().init(edge2);
+        train.eventFactory().init(0, edge2);
 
         Train.State state = train.getState(0);
         assertEquals(train.getLength(), state.getPosition().getFrontDistance());
         assertEquals(edge2, state.getPosition().getFrontEdge());
         assertEquals(0, state.getPosition().getBackDistance());
         assertEquals(0, state.getTotalDistance());
+        assertTrue(state.isInitialized());
     }
 
     @Test
     public void testSpeed() {
         Train train = Train.in(context).create("t", "train", 10);
         Edge edge = createEdges(50)[0];
-        train.eventFactory().init(edge);
+        train.eventFactory().init(0, edge);
 
         Train.State initState = train.getState(0);
 
@@ -156,6 +161,7 @@ public class TrainTest {
         assertEquals(train.getLength() + distance, state.getPosition().getFrontDistance());
         assertEquals(speed, state.getSpeed());
         assertEquals(distance, state.getTotalDistance());
+        assertTrue(state.isInitialized());
 
         assertEquals(state, train.getState(20));
     }
@@ -164,7 +170,7 @@ public class TrainTest {
     public void testReach() {
         Train train = Train.in(context).create("t", "train", 10);
         Edge[] edges = createEdges(20, 40);
-        train.eventFactory().init(edges[0]);
+        train.eventFactory().init(0, edges[0]);
 
         train.eventFactory().reach(10, edges[1], 10);
         Train.State state = train.getState(10);
@@ -182,7 +188,7 @@ public class TrainTest {
     public void testLeave() {
         Train train = Train.in(context).create("t", "train", 10);
         Edge[] edges = createEdges(20, 40);
-        train.eventFactory().init(edges[0]);
+        train.eventFactory().init(0, edges[0]);
 
         train.eventFactory().reach(10, edges[1], 10);
         train.eventFactory().leave(20, edges[0], 10);
@@ -201,7 +207,7 @@ public class TrainTest {
     public void testTerminate() {
         Train train = Train.in(context).create("t", "train", 10);
         Edge edge = createEdges(20)[0];
-        train.eventFactory().init(edge);
+        train.eventFactory().init(0, edge);
 
         train.eventFactory().speed(5, 2, 20);
         train.eventFactory().terminate(10, 2);
@@ -217,7 +223,7 @@ public class TrainTest {
     public void testSpeedInterpolation() {
         Train train = Train.in(context).create("t", "train", 10);
         Edge edge = createEdges(50)[0];
-        train.eventFactory().init(edge);
+        train.eventFactory().init(0, edge);
 
         train.eventFactory().speed(10, 5, 10);
         train.eventFactory().speed(20, 5, 20);
@@ -231,7 +237,7 @@ public class TrainTest {
     public void testSpeedInterpolationWithNonSpeedInbetween() {
         Train train = Train.in(context).create("t", "train", 10);
         Edge[] edges = createEdges(10, 50);
-        train.eventFactory().init(edges[0]);
+        train.eventFactory().init(0, edges[0]);
 
         train.eventFactory().speed(10, 5, 10);
         train.eventFactory().leave(15, edges[1], 5);
@@ -246,7 +252,7 @@ public class TrainTest {
     public void testPositionInterpolation() {
         Train train = Train.in(context).create("t", "train", 10);
         Edge edge = createEdges(50)[0];
-        train.eventFactory().init(edge);
+        train.eventFactory().init(0, edge);
 
         train.eventFactory().speed(10, 10, 5);
 
@@ -259,7 +265,7 @@ public class TrainTest {
     public void testDistanceInterpolation() {
         Train train = Train.in(context).create("t", "train", 10);
         Edge edge = createEdges(50)[0];
-        train.eventFactory().init(edge);
+        train.eventFactory().init(0, edge);
 
         train.eventFactory().speed(10, 10, 10);
         train.eventFactory().speed(20, 10, 20);
@@ -275,7 +281,7 @@ public class TrainTest {
     public void testMergeEvents() {
         Train train = Train.in(context).create("t", "train", 10);
         Edge[] edges = createEdges(20, 20);
-        train.eventFactory().init(edges[0]);
+        train.eventFactory().init(0, edges[0]);
 
         train.eventFactory().reach(10, edges[1], 10);
         train.eventFactory().speed(10, 5, 10);
@@ -290,7 +296,7 @@ public class TrainTest {
     public void testGetStateWithStart() {
         Train train = Train.in(context).create("t", "train", 10);
         Edge[] edges = createEdges(20, 20);
-        train.eventFactory().init(edges[0]);
+        train.eventFactory().init(0, edges[0]);
 
         train.eventFactory().reach(10, edges[1], 10);
         train.eventFactory().speed(20, 5, 10);
@@ -305,7 +311,7 @@ public class TrainTest {
     public void testGetStateWithStartAfterWanted() {
         Train train = Train.in(context).create("t", "train", 10);
         Edge[] edges = createEdges(20, 20);
-        train.eventFactory().init(edges[0]);
+        train.eventFactory().init(0, edges[0]);
 
         train.eventFactory().reach(10, edges[1], 10);
         train.eventFactory().speed(20, 5, 10);
@@ -320,7 +326,7 @@ public class TrainTest {
     public void testGetStateWithStartNull() {
         Train train = Train.in(context).create("t", "train", 10);
         Edge[] edges = createEdges(20);
-        train.eventFactory().init(edges[0]);
+        train.eventFactory().init(0, edges[0]);
 
         expected.expect(NullPointerException.class);
         train.getState(10, null);
@@ -332,8 +338,8 @@ public class TrainTest {
         Train train2 = Train.in(context).create("t2", "train2", 20);
         Edge[] edges = createEdges(20, 20);
 
-        train.eventFactory().init(edges[0]);
-        train2.eventFactory().init(edges[0]);
+        train.eventFactory().init(0, edges[0]);
+        train2.eventFactory().init(0, edges[0]);
 
         Train.State state = train2.getState(5);
         expected.expect(IllegalArgumentException.class);
@@ -344,9 +350,9 @@ public class TrainTest {
     public void testInitAlreadyInitialized() {
         Train train = Train.in(context).create("t", "train", 10);
         Edge[] edges = createEdges(20, 20);
-        train.eventFactory().init(edges[0]);
+        train.eventFactory().init(0, edges[0]);
         expected.expect(IllegalStateException.class);
-        train.eventFactory().init(edges[1]);
+        train.eventFactory().init(0, edges[1]);
     }
 
     @Test
@@ -383,7 +389,7 @@ public class TrainTest {
     public void testSpeedAlreadyTerminated() {
         Train train = Train.in(context).create("t", "train", 10);
         Edge edge = createEdges(50)[0];
-        train.eventFactory().init(edge);
+        train.eventFactory().init(0, edge);
         train.eventFactory().terminate(5, 0);
         train.eventFactory().speed(10, 10, 10);
         assertFalse(train.getEvents().get(train.getEvents().size() - 1).getWarnings().isEmpty());
@@ -393,7 +399,7 @@ public class TrainTest {
     public void testReachAlreadyTerminated() {
         Train train = Train.in(context).create("t", "train", 10);
         Edge edge = createEdges(50)[0];
-        train.eventFactory().init(edge);
+        train.eventFactory().init(0, edge);
         train.eventFactory().terminate(5, 0);
         train.eventFactory().reach(10, edge, 10);
         assertFalse(train.getEvents().get(train.getEvents().size() - 1).getWarnings().isEmpty());
@@ -403,7 +409,7 @@ public class TrainTest {
     public void testLeaveAlreadyTerminated() {
         Train train = Train.in(context).create("t", "train", 10);
         Edge edge = createEdges(50)[0];
-        train.eventFactory().init(edge);
+        train.eventFactory().init(0, edge);
         train.eventFactory().terminate(5, 0);
         train.eventFactory().leave(10, edge, 10);
         assertFalse(train.getEvents().get(train.getEvents().size() - 1).getWarnings().isEmpty());
@@ -413,7 +419,7 @@ public class TrainTest {
     public void testTerminateAlreadyTerminated() {
         Train train = Train.in(context).create("t", "train", 10);
         Edge edge = createEdges(50)[0];
-        train.eventFactory().init(edge);
+        train.eventFactory().init(0, edge);
         train.eventFactory().terminate(5, 0);
         train.eventFactory().terminate(10, 10);
         assertFalse(train.getEvents().get(train.getEvents().size() - 1).getWarnings().isEmpty());
@@ -423,7 +429,7 @@ public class TrainTest {
     public void testEventBeforeLast() {
         Train train = Train.in(context).create("t", "train", 10);
         Edge edge = createEdges(50)[0];
-        train.eventFactory().init(edge);
+        train.eventFactory().init(0, edge);
         train.eventFactory().speed(10, 10, 20);
         train.eventFactory().speed(5, 10, 10);
         Event event = train.getEvents().get(2);

--- a/src/test/java/com/github/bachelorpraktikum/dbvisualization/model/TrainTest.java
+++ b/src/test/java/com/github/bachelorpraktikum/dbvisualization/model/TrainTest.java
@@ -431,10 +431,16 @@ public class TrainTest {
         Edge edge = createEdges(50)[0];
         train.eventFactory().init(0, edge);
         train.eventFactory().speed(10, 10, 20);
+        Event beforeEvent = train.getEvents().get(train.getEvents().size() - 1);
         train.eventFactory().speed(5, 10, 10);
-        Event event = train.getEvents().get(2);
-        assertFalse(event.getWarnings().isEmpty());
-        assertEquals(10, event.getTime());
-        assertEquals(train.getEvents().get(1).getTime(), event.getTime());
+        Event newEvent = train.getEvents().get(train.getEvents().size() - 1);
+        assertTrue(beforeEvent != newEvent);
+
+        assertTrue(beforeEvent.getWarnings().isEmpty());
+        assertEquals(10, beforeEvent.getTime());
+
+        assertFalse(newEvent.getWarnings().isEmpty());
+        assertEquals(10, newEvent.getTime());
+        assertEquals(beforeEvent.getTime(), newEvent.getTime());
     }
 }


### PR DESCRIPTION
Add time to train init event.
In order to implement this, some changes had to be made to the model:
- The train state can be uninitialized now (before the time of the init event)
  - Calling getPosition() on an uninitialized state will throw an exception
  - Uninitialized trains will not be shown on the graph
- A start event is added at time 0. It represents the start of the timeline for the train and creates an uninitialized state
  - The start event makes interpolation easier, because this way it is guaranteed that there will always be an event for time >= 0