### PR TITLE
Set simulation init state to -1. TG-63

### DIFF
--- a/src/main/java/com/github/bachelorpraktikum/dbvisualization/model/Context.java
+++ b/src/main/java/com/github/bachelorpraktikum/dbvisualization/model/Context.java
@@ -16,6 +16,7 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 public final class Context {
+    public static final int INIT_STATE_TIME = -1;
 
     private final List<Object> objects;
 

--- a/src/main/java/com/github/bachelorpraktikum/dbvisualization/model/Element.java
+++ b/src/main/java/com/github/bachelorpraktikum/dbvisualization/model/Element.java
@@ -4,7 +4,6 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -12,17 +11,15 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.WeakHashMap;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import javax.annotation.ParametersAreNonnullByDefault;
-
 import javafx.beans.property.ReadOnlyObjectWrapper;
 import javafx.beans.property.ReadOnlyProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.SortedList;
 import javafx.scene.paint.Color;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 /**
  * Represents an element on the track.<p>Every element is associated with a {@link Node}.</p>
@@ -182,7 +179,7 @@ public final class Element {
         }
 
         // Add an event at time 0 with the initial state
-        factory.addEvent(this, state, 0);
+        factory.addEvent(this, state, Context.INIT_STATE_TIME);
     }
 
     /**
@@ -287,11 +284,10 @@ public final class Element {
         }
 
         private void addEvent(Element element, State state, int time) {
-            List<String> warnings = new LinkedList<>();
-            if (time < 0) {
-                warnings.add("original time was " + time);
-                time = 0;
-            }
+            addEvent(element, state, new LinkedList<>(), time);
+        }
+
+        private void addEvent(Element element, State state, List<String> warnings, int time) {
             if (!events.isEmpty() && time < events.get(events.size() - 1).getTime()) {
                 warnings.add("tried to add before last event at " + time);
                 time = events.get(events.size() - 1).getTime();
@@ -306,7 +302,7 @@ public final class Element {
         }
 
         private void resetTime() {
-            currentTime = -1;
+            currentTime = Context.INIT_STATE_TIME;
             nextIndex = 0;
         }
 
@@ -314,11 +310,11 @@ public final class Element {
          * Changes the time for all {@link Element elements} in this context.
          *
          * @param time the time in milliseconds
-         * @throws IllegalArgumentException if time is negative
+         * @throws IllegalArgumentException if time is less than {@link Context#INIT_STATE_TIME}
          */
         public void setTime(int time) {
-            if (time < 0) {
-                throw new IllegalArgumentException("negative time: " + time);
+            if (time < -1) {
+               throw new IllegalArgumentException("invalid time: " + time);
             }
 
             if (time == currentTime) {
@@ -370,7 +366,12 @@ public final class Element {
      * @throws IllegalArgumentException if time is negative
      */
     public void addEvent(State state, int time) {
-        getFactory().addEvent(this, Objects.requireNonNull(state), time);
+        List<String> warnings = new LinkedList<>();
+        if (time < 0) {
+            warnings.add("original time was " + time);
+            time = 0;
+        }
+        getFactory().addEvent(this, Objects.requireNonNull(state), warnings, time);
     }
 
     /**

--- a/src/main/java/com/github/bachelorpraktikum/dbvisualization/model/Element.java
+++ b/src/main/java/com/github/bachelorpraktikum/dbvisualization/model/Element.java
@@ -358,12 +358,12 @@ public final class Element {
 
     /**
      * Adds an event for this {@link Element}.
+     * If the time is negative, it will be corrected to 0 and a warning will be added to the event.
      *
      * @param state new state after this event
      * @param time  the time of the event in milliseconds
      * @throws NullPointerException     if state is null
      * @throws IllegalStateException    if there is already another event after this one
-     * @throws IllegalArgumentException if time is negative
      */
     public void addEvent(State state, int time) {
         List<String> warnings = new LinkedList<>();

--- a/src/main/java/com/github/bachelorpraktikum/dbvisualization/model/train/InterpolatableState.java
+++ b/src/main/java/com/github/bachelorpraktikum/dbvisualization/model/train/InterpolatableState.java
@@ -1,5 +1,6 @@
 package com.github.bachelorpraktikum.dbvisualization.model.train;
 
+import com.github.bachelorpraktikum.dbvisualization.model.Context;
 import java.util.Objects;
 
 import javax.annotation.Nonnull;
@@ -44,7 +45,7 @@ final class InterpolatableState implements Train.State {
         @Nonnull
         private final Train train;
 
-        private int time = -1;
+        private int time = Integer.MIN_VALUE;
         private int speed = -1;
         private boolean terminated = false;
         private boolean initialized = true;
@@ -71,7 +72,7 @@ final class InterpolatableState implements Train.State {
          * @throws IllegalArgumentException if time is negative
          */
         Builder time(int time) {
-            if (time < 0) {
+            if (time < Context.INIT_STATE_TIME) {
                 throw new IllegalArgumentException("time is negative");
             }
             this.time = time;
@@ -175,7 +176,7 @@ final class InterpolatableState implements Train.State {
          * @throws IllegalStateException if any of the required values have not been set.
          */
         InterpolatableState build() {
-            if (time < 0
+            if (time < Context.INIT_STATE_TIME
                     || speed < 0
                     || index < 0
                     || distance < 0

--- a/src/main/java/com/github/bachelorpraktikum/dbvisualization/model/train/Train.java
+++ b/src/main/java/com/github/bachelorpraktikum/dbvisualization/model/train/Train.java
@@ -202,7 +202,7 @@ public class Train {
      *
      * @param time the time in milliseconds since the start of the simulation
      * @return the state of the train at the given point in time.
-     * @throws IllegalArgumentException if time is negative
+     * @throws IllegalArgumentException if time is less than {@link Context#INIT_STATE_TIME}
      * @throws IllegalStateException    if this train has not been {@link EventFactory#init(int, Edge)
      *                                  initialized}
      */
@@ -220,7 +220,7 @@ public class Train {
      * @param time   the time in milliseconds since the start of the simulation
      * @param before the state to use as a jumping off point
      * @return the state of the train at the given point in time.
-     * @throws IllegalArgumentException if time is negative
+     * @throws IllegalArgumentException if time is less than {@link Context#INIT_STATE_TIME}
      * @throws IllegalArgumentException if before is a state of a different train
      * @throws NullPointerException     if before is null
      * @throws IllegalStateException    if this train has not been {@link EventFactory#init(int, Edge)
@@ -249,8 +249,12 @@ public class Train {
 
     @Nonnull
     private State getState(int time, int startingIndex) {
-        if (time < 0) {
-            throw new IllegalArgumentException("time is negative");
+        if (time < Context.INIT_STATE_TIME) {
+            throw new IllegalArgumentException("time is too small");
+        }
+
+        if(time < 0) {
+         //   return events.get(0).getState();
         }
 
         Iterator<TrainEvent> iterator = events.listIterator(startingIndex);

--- a/src/main/java/com/github/bachelorpraktikum/dbvisualization/model/train/Train.java
+++ b/src/main/java/com/github/bachelorpraktikum/dbvisualization/model/train/Train.java
@@ -253,10 +253,6 @@ public class Train {
             throw new IllegalArgumentException("time is too small");
         }
 
-        if(time < 0) {
-         //   return events.get(0).getState();
-        }
-
         Iterator<TrainEvent> iterator = events.listIterator(startingIndex);
         TrainEvent result = iterator.next();
 

--- a/src/main/java/com/github/bachelorpraktikum/dbvisualization/model/train/TrainEvent.java
+++ b/src/main/java/com/github/bachelorpraktikum/dbvisualization/model/train/TrainEvent.java
@@ -1,5 +1,6 @@
 package com.github.bachelorpraktikum.dbvisualization.model.train;
 
+import com.github.bachelorpraktikum.dbvisualization.model.Context;
 import com.github.bachelorpraktikum.dbvisualization.model.Edge;
 import com.github.bachelorpraktikum.dbvisualization.model.Event;
 import com.github.bachelorpraktikum.dbvisualization.model.Node;
@@ -168,7 +169,7 @@ abstract class TrainEvent implements Event {
     @ParametersAreNonnullByDefault
     static class Start extends Speed {
         Start(Train train) {
-            super(0, train, 0, 0, 0, () -> null, 0);
+            super(0, train, Context.INIT_STATE_TIME, 0, 0, () -> null, 0);
         }
 
         @Nonnull

--- a/src/main/java/com/github/bachelorpraktikum/dbvisualization/view/MainController.java
+++ b/src/main/java/com/github/bachelorpraktikum/dbvisualization/view/MainController.java
@@ -119,6 +119,8 @@ public class MainController {
     @FXML
     private ListView<Event> logList;
     @FXML
+    private Button resetButton;
+    @FXML
     private TextField timeText;
     @FXML
     private HBox rightSpacer;
@@ -159,6 +161,7 @@ public class MainController {
         fireOnEnterPress(closeButton);
         fireOnEnterPress(logToggle);
         closeButton.setOnAction(event -> showSourceChooser());
+        resetButton.setOnAction(event -> simulationTime.set(Context.INIT_STATE_TIME));
 
         legendButton.selectedProperty().addListener((observable, oldValue, newValue) -> {
             legend.setVisible(newValue);
@@ -570,6 +573,7 @@ public class MainController {
                 return;
         }
 
+        simulationTime.set(Context.INIT_STATE_TIME);
         showElements();
     }
 

--- a/src/main/java/com/github/bachelorpraktikum/dbvisualization/view/MainView.fxml
+++ b/src/main/java/com/github/bachelorpraktikum/dbvisualization/view/MainView.fxml
@@ -27,7 +27,8 @@
                     <items>
                         <ToggleButton fx:id="logToggle" text="%show_hide_logs"/>
                         <Label text="%current_simulation_time"/>
-                        <TextField fx:id="timeText" prefHeight="25.0" prefWidth="100.0" text="0ms"/>
+                        <TextField fx:id="timeText" prefHeight="25.0" prefWidth="100.0" text="-1ms"/>
+                        <Button fx:id="resetButton" text="%reset"/>
                         <Label text="%velocity"/>
                         <TextField fx:id="velocityText" prefWidth="100.0" text="1000"/>
                         <ToggleButton fx:id="playToggle" text="%play_simulation"/>

--- a/src/main/resources/bundles/localization.properties
+++ b/src/main/resources/bundles/localization.properties
@@ -33,3 +33,4 @@ eventTravsersal=Traverse
 coordinate_back=Back
 coordinate_front=Front
 unavailable=Unavailable
+reset=Reset

--- a/src/main/resources/bundles/localization_de_DE.properties
+++ b/src/main/resources/bundles/localization_de_DE.properties
@@ -32,3 +32,4 @@ eventTravsersal=Durchlaufen
 coordinate_back=Heck
 coordinate_front=Front
 unavailable=Nicht verfügbar
+reset=Zurücksetzen

--- a/src/test/java/com/github/bachelorpraktikum/dbvisualization/model/ElementTest.java
+++ b/src/test/java/com/github/bachelorpraktikum/dbvisualization/model/ElementTest.java
@@ -120,7 +120,7 @@ public class ElementTest {
         boolean hasZeroTime = false;
         boolean zeroTimeHasWarnings = false;
         for (Event event : Element.in(context).getEvents()) {
-            assertFalse(event.getTime() < 0);
+            assertFalse(event.getTime() < Context.INIT_STATE_TIME);
             if (event.getTime() == 0) {
                 hasZeroTime = true;
                 if (!event.getWarnings().isEmpty()) {

--- a/src/test/java/com/github/bachelorpraktikum/dbvisualization/model/TrainTest.java
+++ b/src/test/java/com/github/bachelorpraktikum/dbvisualization/model/TrainTest.java
@@ -90,13 +90,13 @@ public class TrainTest {
     }
 
     @Test
-    public void testGetStateNegativeTime() {
+    public void testGetStateNegativeTimeBeforeInit() {
         Train train = Train.in(context).create("t", "train", 20);
         Edge edge = createEdges(30)[0];
         train.eventFactory().init(0, edge);
 
         expected.expect(IllegalArgumentException.class);
-        train.getState(-1);
+        train.getState(Context.INIT_STATE_TIME - 1);
     }
 
     @Test


### PR DESCRIPTION
This creates an artificial difference between element initialization time and 0ms.

I have added a reset button to set the simulation time to -1. This way we don't need to allow the user to manually enter a negative simulation time.