### PR TITLE
Cache maven dependencies on CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,7 @@
 dependencies:
   override:
       - mvn --fail-never dependency:go-offline || true
+      - mvn --fail-never dependency:resolve-plugins || true
 
 test:
   post:

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,8 @@
+
+dependencies:
+  override:
+      - mvn --fail-never dependency:go-offline || true
+
 test:
   post:
     - mvn site -P site


### PR DESCRIPTION
This isn't perfect (it doesn't cache dependencies for the maven report, and also some others), but it's something...