### PR TITLE
Fix method header in LegendListViewCell

### DIFF
--- a/src/main/java/com/github/bachelorpraktikum/dbvisualization/view/legend/LegendListViewCell.java
+++ b/src/main/java/com/github/bachelorpraktikum/dbvisualization/view/legend/LegendListViewCell.java
@@ -29,8 +29,8 @@ public class LegendListViewCell extends ListCell<Shapeable> {
     @FXML
     private AnchorPane cell;
 
-
-    protected void updateItem(Shapeable<?> element, boolean empty) {
+    @Override
+    protected void updateItem(Shapeable element, boolean empty) {
         super.updateItem(element, empty);
         if (empty) {
             setText(null);


### PR DESCRIPTION
Fixes bug introduced by 50c0fbe518493e9b412c4504e41be9bfeed97e8a .
Textbook example of why the `@Override` annotation should always be used.