### PR TITLE
Add options to pipe in data and skip chooser window

### DIFF
--- a/src/main/java/com/github/bachelorpraktikum/dbvisualization/DBVisualizer.java
+++ b/src/main/java/com/github/bachelorpraktikum/dbvisualization/DBVisualizer.java
@@ -1,7 +1,10 @@
 package com.github.bachelorpraktikum.dbvisualization;
 
 import com.github.bachelorpraktikum.dbvisualization.config.ConfigFile;
+import com.github.bachelorpraktikum.dbvisualization.datasource.DataSource;
+import com.github.bachelorpraktikum.dbvisualization.datasource.RestSource;
 import com.github.bachelorpraktikum.dbvisualization.view.DataSourceHolder;
+import com.github.bachelorpraktikum.dbvisualization.view.MainController;
 import com.github.bachelorpraktikum.dbvisualization.view.sourcechooser.SourceController;
 import java.io.IOException;
 import java.io.InputStream;
@@ -31,15 +34,6 @@ public class DBVisualizer extends Application {
     public void start(Stage primaryStage) throws Exception {
         ResourceBundle localizationBundle = ResourceBundle.getBundle("bundles.localization");
         primaryStage.setTitle(localizationBundle.getString(APP_NAME_KEY));
-
-        FXMLLoader loader = new FXMLLoader(
-            getClass().getResource("view/sourcechooser/SourceChooser.fxml")
-        );
-        loader.setResources(localizationBundle);
-        loader.load();
-        SourceController controller = loader.getController();
-
-        controller.setStage(primaryStage);
         primaryStage.setOnHiding(event ->
             DataSourceHolder.getInstance().ifPresent(dataSource -> {
                 try {
@@ -49,6 +43,35 @@ public class DBVisualizer extends Application {
                 }
             })
         );
+
+        FXMLLoader loader = new FXMLLoader();
+        loader.setResources(localizationBundle);
+
+        if (getParameters().getUnnamed().contains("--live")) {
+            log.info("Loading...");
+            // skip the chooser window
+            loader.setLocation(
+                getClass().getResource("view/MainView.fxml")
+            );
+
+            // start the REST-Source
+            DataSource dataSource = new RestSource();
+
+            log.info("Launching GUI...");
+            loader.load();
+            MainController controller = loader.getController();
+            controller.setDataSource(dataSource);
+            controller.setStage(primaryStage);
+        } else {
+            loader.setLocation(
+                getClass().getResource("view/sourcechooser/SourceChooser.fxml")
+            );
+
+            loader.load();
+            SourceController controller = loader.getController();
+            controller.setStage(primaryStage);
+        }
+
         primaryStage.show();
     }
 

--- a/src/main/java/com/github/bachelorpraktikum/dbvisualization/DBVisualizer.java
+++ b/src/main/java/com/github/bachelorpraktikum/dbvisualization/DBVisualizer.java
@@ -2,6 +2,7 @@ package com.github.bachelorpraktikum.dbvisualization;
 
 import com.github.bachelorpraktikum.dbvisualization.config.ConfigFile;
 import com.github.bachelorpraktikum.dbvisualization.datasource.DataSource;
+import com.github.bachelorpraktikum.dbvisualization.datasource.InputParserSource;
 import com.github.bachelorpraktikum.dbvisualization.datasource.RestSource;
 import com.github.bachelorpraktikum.dbvisualization.view.DataSourceHolder;
 import com.github.bachelorpraktikum.dbvisualization.view.MainController;
@@ -47,17 +48,23 @@ public class DBVisualizer extends Application {
         FXMLLoader loader = new FXMLLoader();
         loader.setResources(localizationBundle);
 
-        if (getParameters().getUnnamed().contains("--live")) {
+        if (getParameters().getUnnamed().contains("--live")
+            || getParameters().getUnnamed().contains("--pipe")) {
             log.info("Loading...");
+
+            DataSource dataSource;
+            // start the data source
+            if (getParameters().getUnnamed().contains("--live")) {
+                dataSource = new RestSource();
+            } else {
+                dataSource = new InputParserSource(System.in);
+            }
+
+            log.info("Launching GUI...");
             // skip the chooser window
             loader.setLocation(
                 getClass().getResource("view/MainView.fxml")
             );
-
-            // start the REST-Source
-            DataSource dataSource = new RestSource();
-
-            log.info("Launching GUI...");
             loader.load();
             MainController controller = loader.getController();
             controller.setDataSource(dataSource);

--- a/src/main/java/com/github/bachelorpraktikum/dbvisualization/datasource/InputParserSource.java
+++ b/src/main/java/com/github/bachelorpraktikum/dbvisualization/datasource/InputParserSource.java
@@ -1,0 +1,105 @@
+package com.github.bachelorpraktikum.dbvisualization.datasource;
+
+import com.github.bachelorpraktikum.dbvisualization.logparser.GraphParser;
+import com.github.bachelorpraktikum.dbvisualization.model.Context;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
+
+class InputParserSource implements DataSource {
+
+    private final Context context;
+    private final ScheduledExecutorService scheduler;
+    private final GraphParser graphParser;
+
+    /**
+     * Callers of this constructor should call {@link #listenToInput(InputStream, long, TimeUnit)}
+     * once after finished initialization.
+     */
+    InputParserSource() {
+        this.context = new Context();
+        this.scheduler = Executors.newSingleThreadScheduledExecutor();
+        this.graphParser = new GraphParser();
+    }
+
+    /**
+     * Listens to subprocess output and parses it until there is no new output for the specified
+     * time.
+     *
+     * @param inputStream the input stream to listen to
+     * @param timeout the timeout
+     * @param unit the unit of the timeout
+     */
+    synchronized void listenToInput(InputStream inputStream, long timeout, TimeUnit unit) {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
+
+        try (PipedOutputStream parserOutStream = new PipedOutputStream();
+            PipedInputStream parserInStream = new PipedInputStream(parserOutStream)) {
+            BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(parserOutStream));
+            // launch the piping thread which pipes the process output into the parser input
+            launchPipingThread(reader, writer, timeout, unit);
+            // this method runs / blocks until the piping thread closes the parserInputStream
+            graphParser.parse(parserInStream, context);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private synchronized void launchPipingThread(
+        BufferedReader reader,
+        BufferedWriter writer,
+        long timeout,
+        TimeUnit unit) {
+        Runnable readWhileReady = () -> {
+            try {
+                while (reader.ready()) {
+                    String line = reader.readLine();
+                    if (line != null) {
+                        writer.write(line);
+                        writer.write('\n');
+                    }
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        };
+
+        Runnable readAndRescheduleUntilTimeout = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    if (!reader.ready()) {
+                        writer.close();
+                    } else {
+                        readWhileReady.run();
+                        scheduler.schedule(this, timeout, unit);
+                    }
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        };
+
+        readWhileReady.run();
+        scheduler.schedule(readAndRescheduleUntilTimeout, timeout, unit);
+    }
+
+    @Nonnull
+    public Context getContext() {
+        return context;
+    }
+
+    @Override
+    public void close() throws IOException {
+        scheduler.shutdownNow();
+    }
+}

--- a/src/main/java/com/github/bachelorpraktikum/dbvisualization/datasource/RestSource.java
+++ b/src/main/java/com/github/bachelorpraktikum/dbvisualization/datasource/RestSource.java
@@ -1,8 +1,10 @@
 package com.github.bachelorpraktikum.dbvisualization.datasource;
 
+import com.github.bachelorpraktikum.dbvisualization.model.Context;
 import com.github.bachelorpraktikum.dbvisualization.model.Element;
 import com.github.bachelorpraktikum.dbvisualization.model.train.Train;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -22,7 +24,7 @@ import retrofit2.Response;
 import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;
 
-public class RestSource extends SubprocessSource {
+public class RestSource implements DataSource {
 
     private static final Logger log = Logger.getLogger(RestSource.class.getName());
 
@@ -31,14 +33,45 @@ public class RestSource extends SubprocessSource {
         .baseUrl("http://localhost:8080")
         .build();
 
+    private final InputParserSource inputParserSource;
+    private final InputStream inputStream;
     private final SimulationService service;
     private final Property<LiveTime> currentTime;
     private final Map<Element, String> signals;
 
+    /**
+     * Creates a REST-Source that starts a model subprocess and listens to its output.
+     *
+     * @param appPath the path to the model executable
+     * @throws IOException if a network error occurs
+     * @throws IOException if the subprocess can't be started
+     */
     public RestSource(String appPath) throws IOException {
-        super(appPath);
+        SubprocessSource inputSource = new SubprocessSource(appPath);
+        this.inputParserSource = inputSource;
+        this.inputStream = inputSource.getInputStream();
         this.service = RETROFIT.create(SimulationService.class);
         this.currentTime = new SimpleObjectProperty<>();
+        this.signals = loadSignals();
+    }
+
+    /**
+     * Creates a REST-Source that listens for model output on System.in.
+     *
+     * @throws IOException if a network error occurs
+     */
+    public RestSource() throws IOException {
+        this.inputParserSource = new InputParserSource();
+        this.inputStream = System.in;
+        this.service = RETROFIT.create(SimulationService.class);
+        this.currentTime = new SimpleObjectProperty<>();
+
+        inputParserSource.listenToInput(
+            inputStream,
+            SubprocessSource.DEFAULT_START_TIMEOUT,
+            TimeUnit.MILLISECONDS
+        );
+
         this.signals = loadSignals();
     }
 
@@ -106,7 +139,7 @@ public class RestSource extends SubprocessSource {
             e.printStackTrace();
             return;
         }
-        listenToOutput(200, TimeUnit.MILLISECONDS);
+        inputParserSource.listenToInput(inputStream, 200, TimeUnit.MILLISECONDS);
         currentTime.setValue(fetchTime());
     }
 
@@ -133,13 +166,19 @@ public class RestSource extends SubprocessSource {
                 } else {
                     log.severe("Break element failed. Error code: " + response.code());
                 }
-                Platform.runLater(onDone);
+                onDone();
             }
 
             @Override
             public void onFailure(Call<ResponseBody> call, Throwable throwable) {
                 log.severe("Failed to execute breakNow call." + throwable);
-                Platform.runLater(onDone);
+                onDone();
+            }
+
+            private void onDone() {
+                if (onDone != null) {
+                    Platform.runLater(onDone);
+                }
             }
         });
     }
@@ -201,5 +240,16 @@ public class RestSource extends SubprocessSource {
 
     public ReadOnlyProperty<LiveTime> timeProperty() {
         return currentTime;
+    }
+
+    @Nonnull
+    @Override
+    public Context getContext() {
+        return inputParserSource.getContext();
+    }
+
+    @Override
+    public void close() throws IOException {
+        inputParserSource.close();
     }
 }

--- a/src/main/java/com/github/bachelorpraktikum/dbvisualization/datasource/RestSource.java
+++ b/src/main/java/com/github/bachelorpraktikum/dbvisualization/datasource/RestSource.java
@@ -68,7 +68,7 @@ public class RestSource implements DataSource {
 
         inputParserSource.listenToInput(
             inputStream,
-            SubprocessSource.DEFAULT_START_TIMEOUT,
+            InputParserSource.DEFAULT_START_TIMEOUT,
             TimeUnit.MILLISECONDS
         );
 
@@ -251,5 +251,6 @@ public class RestSource implements DataSource {
     @Override
     public void close() throws IOException {
         inputParserSource.close();
+        log.info("Successfully closed REST-Source");
     }
 }

--- a/src/main/java/com/github/bachelorpraktikum/dbvisualization/datasource/SubprocessSource.java
+++ b/src/main/java/com/github/bachelorpraktikum/dbvisualization/datasource/SubprocessSource.java
@@ -1,36 +1,22 @@
 package com.github.bachelorpraktikum.dbvisualization.datasource;
 
-import com.github.bachelorpraktikum.dbvisualization.logparser.GraphParser;
 import com.github.bachelorpraktikum.dbvisualization.model.Context;
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
-import java.io.PipedInputStream;
-import java.io.PipedOutputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nonnull;
 
 /**
  * Can be used to start a simulation subprocess and parse its output.
  */
-public class SubprocessSource implements DataSource {
+public class SubprocessSource extends InputParserSource {
 
     public static final long DEFAULT_START_TIMEOUT = 1000;
 
-    private final Context context;
     private final Process process;
-    private final ScheduledExecutorService scheduler;
-
-    private final GraphParser graphParser;
 
     /**
      * Creates a new {@link Context} and starts the process specified by the command with the
@@ -44,78 +30,21 @@ public class SubprocessSource implements DataSource {
      * @throws IOException if the process can't be started
      */
     public SubprocessSource(String command, String... args) throws IOException {
-        this.context = new Context();
         this.process = createProcess(Objects.requireNonNull(command), args);
-        this.scheduler = Executors.newSingleThreadScheduledExecutor();
-
-        this.graphParser = new GraphParser();
 
         // TODO create constructor with the first timeout explicitly given
         // Listen until first output is processed
         // (so Node / Edge / Element / Train declarations are processed before MainWindow is shown)
-        listenToOutput(DEFAULT_START_TIMEOUT, TimeUnit.MILLISECONDS);
+        listenToInput(process.getInputStream(), DEFAULT_START_TIMEOUT, TimeUnit.MILLISECONDS);
     }
 
     /**
-     * Listens to subprocess output and parses it until there is no new output for the specified
-     * time.
+     * Gets the input stream of the subprocess (the output of the subprocess).
      *
-     * @param timeout the timeout
-     * @param unit the unit of the timeout
+     * @return an input stream
      */
-    synchronized void listenToOutput(long timeout, TimeUnit unit) {
-        InputStream inputStream = process.getInputStream();
-        BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
-
-        try (PipedOutputStream parserOutStream = new PipedOutputStream();
-            PipedInputStream parserInStream = new PipedInputStream(parserOutStream)) {
-            BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(parserOutStream));
-            // launch the piping thread which pipes the process output into the parser input
-            launchPipingThread(reader, writer, timeout, unit);
-            // this method runs / blocks until the piping thread closes the parserInputStream
-            graphParser.parse(parserInStream, context);
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
-
-    private synchronized void launchPipingThread(
-        BufferedReader reader,
-        BufferedWriter writer,
-        long timeout,
-        TimeUnit unit) {
-        Runnable readWhileReady = () -> {
-            try {
-                while (reader.ready()) {
-                    String line = reader.readLine();
-                    if (line != null) {
-                        writer.write(line);
-                        writer.write('\n');
-                    }
-                }
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-        };
-
-        Runnable readAndRescheduleUntilTimeout = new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    if (!reader.ready()) {
-                        writer.close();
-                    } else {
-                        readWhileReady.run();
-                        scheduler.schedule(this, timeout, unit);
-                    }
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
-            }
-        };
-
-        readWhileReady.run();
-        scheduler.schedule(readAndRescheduleUntilTimeout, timeout, unit);
+    protected InputStream getInputStream() {
+        return process.getInputStream();
     }
 
     private Process createProcess(String command, String... args) throws IOException {
@@ -126,15 +55,9 @@ public class SubprocessSource implements DataSource {
         return new ProcessBuilder(commands).start();
     }
 
-    @Nonnull
     @Override
-    public final Context getContext() {
-        return context;
-    }
-
-    @Override
-    public void close() {
-        scheduler.shutdownNow();
+    public void close() throws IOException {
+        super.close();
         try {
             // TODO this fails to shut down the model completely.
             // maybe a REST call to call exit could be implemented?

--- a/src/main/java/com/github/bachelorpraktikum/dbvisualization/datasource/SubprocessSource.java
+++ b/src/main/java/com/github/bachelorpraktikum/dbvisualization/datasource/SubprocessSource.java
@@ -14,8 +14,6 @@ import java.util.concurrent.TimeUnit;
  */
 public class SubprocessSource extends InputParserSource {
 
-    public static final long DEFAULT_START_TIMEOUT = 1000;
-
     private final Process process;
 
     /**


### PR DESCRIPTION
This adds two command line options:
- "--pipe" to pipe in the content of a regular log file
  - e.g. "cat test.zug.clean | java -jar visualisierbar.jar --pipe"
- "--live" to pipe in the output of the model process and connect to the process for live simulation
  - e.g. "./runRest | java -jar visualisierbar --live"